### PR TITLE
Create API for submit jobs

### DIFF
--- a/api/cloudformation.yml
+++ b/api/cloudformation.yml
@@ -36,7 +36,7 @@ Resources:
                 content:
                   application/json:
                     schema:
-                      $ref: #/components/schemas/submitJob
+                      $ref: "#/components/schemas/submitJob"
                 required: true
               responses:
                 200:
@@ -44,7 +44,7 @@ Resources:
                   content:
                     application/json:
                       schema:
-                        $ref: #/components/schemas/Empty
+                        $ref: "#/components/schemas/Empty"
               x-amazon-apigateway-request-validator: Validate body
               x-amazon-apigateway-integration:
                 credentials: arn:aws:iam::845172464411:role/asj-api-dev

--- a/api/cloudformation.yml
+++ b/api/cloudformation.yml
@@ -25,10 +25,10 @@ Resources:
           title: hyp3-api
           version: 0.0.1
         servers:
-          - url: https://yxedp20dk1.execute-api.us-west-2.amazonaws.com/{basePath}
+          - url: https://yxedp20dk1.execute-api.us-west-2.amazonaws.com/{basePath} #TODO create custom url
             variables:
               basePath:
-                default: /develop
+                default: /v1
         paths:
           /jobs:
             post:
@@ -47,8 +47,8 @@ Resources:
                         $ref: "#/components/schemas/Empty"
               x-amazon-apigateway-request-validator: Validate body
               x-amazon-apigateway-integration:
-                credentials: arn:aws:iam::845172464411:role/asj-api-dev
-                uri: arn:aws:apigateway:us-west-2:batch:path/v1/submitjob
+                credentials: !GetAtt IamRole.Arn
+                uri: !Sub "arn:aws:apigateway:${AWS::Region}:batch:path/v1/submitjob"
                 responses:
                   default:
                     statusCode: 200

--- a/api/cloudformation.yml
+++ b/api/cloudformation.yml
@@ -39,7 +39,7 @@ Resources:
                       $ref: "#/components/schemas/submitJob"
                 required: true
               responses:
-                200:
+                "200":
                   description: 200 response
                   content:
                     application/json:

--- a/api/cloudformation.yml
+++ b/api/cloudformation.yml
@@ -1,0 +1,118 @@
+AWSTemplateFormatVersion: 2010-09-09
+
+Parameters:
+
+  JobQueueArn:
+    Type: String
+
+  JobDefinition:
+    Type: String
+
+Outputs:
+
+  ApiEndpoint:
+    Value: !Sub "https://${RestApi}.execute-api.${AWS::Region}.amazonaws.com/${Stage}/"
+
+Resources:
+
+  RestApi:
+    Type: AWS::ApiGateway::RestApi
+    Properties:
+      Name: !Ref AWS::StackName
+      Body:
+        openapi: 3.0.1
+        info:
+          title: hyp3-api
+          version: 0.0.1
+        servers:
+          - url: https://yxedp20dk1.execute-api.us-west-2.amazonaws.com/{basePath}
+            variables:
+              basePath:
+                default: /develop
+        paths:
+          /jobs:
+            post:
+              requestBody:
+                content:
+                  application/json:
+                    schema:
+                      $ref: #/components/schemas/submitJob
+                required: true
+              responses:
+                200:
+                  description: 200 response
+                  content:
+                    application/json:
+                      schema:
+                        $ref: #/components/schemas/Empty
+              x-amazon-apigateway-request-validator: Validate body
+              x-amazon-apigateway-integration:
+                credentials: arn:aws:iam::845172464411:role/asj-api-dev
+                uri: arn:aws:apigateway:us-west-2:batch:path/v1/submitjob
+                responses:
+                  default:
+                    statusCode: 200
+                requestTemplates:
+                  application/json: !Sub |-
+                    #set($inputRoot = $input.path('$'))
+                    {
+                       "jobDefinition": "${JobDefinition}",
+                       "jobName": $input.json('$.granule'),
+                       "jobQueue": "${JobQueueArn}",
+                       "parameters": {
+                          "granule" : $input.json('$.granule')
+                       }
+                    }
+                passthroughBehavior: when_no_templates
+                httpMethod: POST
+                type: aws
+        components:
+          schemas:
+            Empty:
+              title: Empty Schema
+              type: object
+            submitJob:
+              title: JobInputModel
+              required:
+                - granule
+              type: object
+              properties:
+                granule:
+                  type: string
+              additionalProperties: false
+        x-amazon-apigateway-request-validators:
+          Validate body:
+            validateRequestParameters: false
+            validateRequestBody: true
+
+  Deployment:
+    Type: AWS::ApiGateway::Deployment
+    Properties:
+      RestApiId: !Ref RestApi
+
+  Stage:
+    Type: AWS::ApiGateway::Stage
+    Properties:
+      StageName: v1
+      RestApiId: !Ref RestApi
+      DeploymentId: !Ref Deployment
+
+  IamRole:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: !Ref AWS::StackName
+      AssumeRolePolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          Action: sts:AssumeRole
+          Principal:
+            Service: apigateway.amazonaws.com
+          Effect: Allow
+      Policies:
+      - PolicyName: policy
+        PolicyDocument:
+          Version: 2012-10-17
+          Statement:
+          - Effect: Allow
+            Action: batch:SubmitJob
+            Resource: !Ref JobQueueArn

--- a/cloudformation.yml
+++ b/cloudformation.yml
@@ -26,7 +26,7 @@ Resources:
         Parameters:
           JobQueueArn: !Ref JobQueue
           JobDefinition: !Ref RtcGammaJobDefinition
-          TemplateURL: launch-instance/cloudformation.yml
+        TemplateURL: api/cloudformation.yml
 
   LaunchInstanceStack:
     Type: AWS::CloudFormation::Stack

--- a/cloudformation.yml
+++ b/cloudformation.yml
@@ -20,6 +20,7 @@ Parameters:
     Default: /aws/service/ecs/optimized-ami/amazon-linux-2/recommended/image_id
 
 Resources:
+
   ApiStack:
       Type: AWS::CloudFormation::Stack
       Properties:

--- a/cloudformation.yml
+++ b/cloudformation.yml
@@ -20,6 +20,13 @@ Parameters:
     Default: /aws/service/ecs/optimized-ami/amazon-linux-2/recommended/image_id
 
 Resources:
+  ApiStack:
+      Type: AWS::CloudFormation::Stack
+      Properties:
+        Parameters:
+          JobQueueArn: !Ref JobQueue
+          JobDefinition: !Ref RtcGammaJobDefinition
+          TemplateURL: launch-instance/cloudformation.yml
 
   LaunchInstanceStack:
     Type: AWS::CloudFormation::Stack


### PR DESCRIPTION
Allows users to create job instances by sending a post request to the api-gateway url with the body

```json
{"granule": "<granule to process>"}
```