### PR TITLE
drop dead letter queues

### DIFF
--- a/launch-instance/cloudformation.yml
+++ b/launch-instance/cloudformation.yml
@@ -12,12 +12,6 @@ Outputs:
 
 Resources:
 
-  DeadLetterQueue:
-    Type: AWS::SQS::Queue
-    Properties:
-      QueueName: !Ref AWS::StackName
-      MessageRetentionPeriod: 1209600
-
   LogGroup:
     Type: AWS::Logs::LogGroup
     Properties:
@@ -46,9 +40,6 @@ Resources:
             - logs:PutLogEvents
             Resource: !GetAtt LogGroup.Arn
           - Effect: Allow
-            Action: sqs:SendMessage
-            Resource: !GetAtt DeadLetterQueue.Arn
-          - Effect: Allow
             Action:
             - ec2:RunInstances
             - ec2:CreateTags
@@ -62,8 +53,6 @@ Resources:
     Properties:
       FunctionName: !Ref AWS::StackName
       Code: src/
-      DeadLetterConfig:
-        TargetArn: !GetAtt DeadLetterQueue.Arn
       Handler: main.lambda_handler
       MemorySize: 128
       Role: !GetAtt Role.Arn

--- a/terminate-idle-instances/cloudformation.yml
+++ b/terminate-idle-instances/cloudformation.yml
@@ -7,12 +7,6 @@ Parameters:
 
 Resources:
 
-  DeadLetterQueue:
-    Type: AWS::SQS::Queue
-    Properties:
-      QueueName: !Ref AWS::StackName
-      MessageRetentionPeriod: 1209600
-
   LogGroup:
     Type: AWS::Logs::LogGroup
     Properties:
@@ -41,9 +35,6 @@ Resources:
             - logs:PutLogEvents
             Resource: !GetAtt LogGroup.Arn
           - Effect: Allow
-            Action: sqs:SendMessage
-            Resource: !GetAtt DeadLetterQueue.Arn
-          - Effect: Allow
             Action:
             - batch:DescribeComputeEnvironments
             - ecs:ListContainerInstances
@@ -56,8 +47,6 @@ Resources:
     Properties:
       FunctionName: !Ref AWS::StackName
       Code: src/
-      DeadLetterConfig:
-        TargetArn: !GetAtt DeadLetterQueue.Arn
       Handler: main.lambda_handler
       MemorySize: 128
       Role: !GetAtt Role.Arn


### PR DESCRIPTION
We'll still have cloudwatch metrics to track lambda errors.  DLQs capture the input events for those failures.  Input events for our launch/terminate lambdas are always the same (a fixed launch template/a fixed compute environment), so they're not worth keeping around.