### PR TITLE
remove job name from api response

### DIFF
--- a/api/hyp3_api/handlers.py
+++ b/api/hyp3_api/handlers.py
@@ -12,7 +12,6 @@ def submit_job(body):
     )
     response = {
         'jobId': job['jobId'],
-        'jobName': job['jobName'],
         'parameters': body,
     }
     return response

--- a/api/hyp3_api/openapi-spec.yml
+++ b/api/hyp3_api/openapi-spec.yml
@@ -31,13 +31,10 @@ components:
       properties:
         jobId:
           type: string
-        jobName:
-          type: string
         parameters:
           $ref: "#/components/schemas/parameters"
       required:
         - jobId
-        - jobName
         - parameters
       additionalProperties: false
     parameters:

--- a/api/tests/test_hyp3_api.py
+++ b/api/tests/test_hyp3_api.py
@@ -57,7 +57,6 @@ def test_submit_job(client, batch_stub):
     assert response.status_code == status.HTTP_200_OK
     assert response.get_json() == {
         'jobId': 'myJobId',
-        'jobName': 'S1B_IW_GRDH_1SDV_20200518T220541_20200518T220610_021641_02915F_82D9',
         'parameters': {
             'granule': 'S1B_IW_GRDH_1SDV_20200518T220541_20200518T220610_021641_02915F_82D9',
         },


### PR DESCRIPTION
Still including the granule name as the Batch job name behind the scenes (for now).