### PR TITLE
add custom domain name for api

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -60,5 +60,5 @@ jobs:
                 "EDLPassword=${EDL_PASSWORD}" \
                 "RtcGammaImage=${RTC_GAMMA_REPOSITORY}:${GITHUB_REF##*/}" \
                 "AuthPublicKey=${AUTH_PUBLIC_KEY}" \
-                "DomainName=hyp3-${GITHUB_REF##*/}.asf.alaska.edu" \
+                "DomainName=hyp3-${GITHUB_REF##*/}-api.asf.alaska.edu" \
                 "CertificateArn=${CERTIFICATE_ARN}"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - master
       - develop
+      - asj-domain-name
 
 env:
   AWS_REGION: us-west-2

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,7 +5,6 @@ on:
     branches:
       - master
       - develop
-      - asj-domain-name
 
 env:
   AWS_REGION: us-west-2

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -28,6 +28,18 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
+      - if: endsWith(github.ref, '/develop')
+        run: |
+          echo "::set-env name=STACK_NAME::hyp3-test"
+          echo "::set-env name=DOMAIN_NAME::hyp3-test-api.asf.alaska.edu"
+          echo "::set-env name=IMAGE_TAG::test"
+
+      - if: endsWith(github.ref, '/master')
+        run: |
+          echo "::set-env name=STACK_NAME::hyp3"
+          echo "::set-env name=DOMAIN_NAME::hyp3-api.asf.alaska.edu"
+          echo "::set-env name=IMAGE_TAG::latest"
+
       - uses: aws-actions/configure-aws-credentials@v1
         with:
           aws-access-key-id: ${{ env.AWS_ACCESS_KEY_ID }}
@@ -49,7 +61,7 @@ jobs:
             --s3-bucket ${TEMPLATE_BUCKET} \
             --output-template-file packaged.yml
           aws cloudformation deploy \
-            --stack-name hyp3-${GITHUB_REF##*/} \
+            --stack-name ${STACK_NAME} \
             --template-file packaged.yml \
             --role-arn ${CLOUDFORMATION_ROLE_ARN} \
             --capabilities CAPABILITY_IAM \
@@ -57,7 +69,7 @@ jobs:
                 "VpcId=${VPC_ID}" \
                 "EDLUsername=${EDL_USERNAME}" \
                 "EDLPassword=${EDL_PASSWORD}" \
-                "RtcGammaImage=${RTC_GAMMA_REPOSITORY}:${GITHUB_REF##*/}" \
+                "RtcGammaImage=${RTC_GAMMA_REPOSITORY}:${IMAGE_TAG}" \
                 "AuthPublicKey=${AUTH_PUBLIC_KEY}" \
-                "DomainName=hyp3-${GITHUB_REF##*/}-api.asf.alaska.edu" \
+                "DomainName=${DOMAIN_NAME}" \
                 "CertificateArn=${CERTIFICATE_ARN}"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,6 +18,7 @@ env:
   AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
   AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
   CLOUDFORMATION_ROLE_ARN: ${{ secrets.CLOUDFORMATION_ROLE_ARN }}
+  CERTIFICATE_ARN: ${{ secrets.CERTIFICATE_ARN }}
 
 jobs:
 
@@ -57,4 +58,6 @@ jobs:
                 "EDLUsername=${EDL_USERNAME}" \
                 "EDLPassword=${EDL_PASSWORD}" \
                 "RtcGammaImage=${RTC_GAMMA_REPOSITORY}:${GITHUB_REF##*/}" \
-                "AuthPublicKey=${AUTH_PUBLIC_KEY}"
+                "AuthPublicKey=${AUTH_PUBLIC_KEY}" \
+                "DomainName=hyp3-${GITHUB_REF##*/}-api.asf.alaska.edu" \
+                "CertificateArn=${CERTIFICATE_ARN}"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -60,5 +60,5 @@ jobs:
                 "EDLPassword=${EDL_PASSWORD}" \
                 "RtcGammaImage=${RTC_GAMMA_REPOSITORY}:${GITHUB_REF##*/}" \
                 "AuthPublicKey=${AUTH_PUBLIC_KEY}" \
-                "DomainName=hyp3-${GITHUB_REF##*/}-api.asf.alaska.edu" \
+                "DomainName=hyp3-${GITHUB_REF##*/}.asf.alaska.edu" \
                 "CertificateArn=${CERTIFICATE_ARN}"

--- a/api/cloudformation.yml
+++ b/api/cloudformation.yml
@@ -99,6 +99,8 @@ Resources:
     Properties:
       DomainName: !Ref CustomDomainName
       RestApiId: !Ref RestApi
+      Stage: !Ref Stage
+      BasePath: !Ref Stage
 
   ApiRole:
     Type: AWS::IAM::Role

--- a/api/cloudformation.yml
+++ b/api/cloudformation.yml
@@ -13,10 +13,16 @@ Parameters:
     Type: String
     Default: RS256
 
+  DomainName:
+    Type: String
+
+  CertificateArn:
+    Type: String
+
 Outputs:
 
   Url:
-    Value: !Sub "https://${RestApi}.execute-api.${AWS::Region}.amazonaws.com/${Stage}/"
+    Value: !Sub "https://${DomainName}/${Stage}/ui"
 
 Resources:
 
@@ -24,6 +30,9 @@ Resources:
     Type: AWS::ApiGateway::RestApi
     Properties:
       Name: !Ref AWS::StackName
+      EndpointConfiguration:
+        Types:
+          - REGIONAL
 
   Resource:
     Type: AWS::ApiGateway::Resource
@@ -74,6 +83,22 @@ Resources:
       StageName: api
       RestApiId: !Ref RestApi
       DeploymentId: !Ref Deployment
+
+  CustomDomainName:
+    Type: AWS::ApiGateway::DomainName
+    Properties:
+      DomainName: !Ref DomainName
+      EndpointConfiguration:
+        Types:
+          - REGIONAL
+      RegionalCertificateArn: !Ref CertificateArn
+      SecurityPolicy: TLS_1_2
+
+  BasePathMapping:
+    Type: AWS::ApiGateway::BasePathMapping
+    Properties:
+      DomainName: !Ref CustomDomainName
+      RestApiId: !Ref RestApi
 
   ApiRole:
     Type: AWS::IAM::Role

--- a/api/cloudformation.yml
+++ b/api/cloudformation.yml
@@ -22,7 +22,7 @@ Parameters:
 Outputs:
 
   Url:
-    Value: !Sub "https://${DomainName}/${Stage}/ui"
+    Value: !Sub "https://${DomainName}/ui"
 
 Resources:
 
@@ -100,7 +100,6 @@ Resources:
       DomainName: !Ref CustomDomainName
       RestApiId: !Ref RestApi
       Stage: !Ref Stage
-      BasePath: !Ref Stage
 
   ApiRole:
     Type: AWS::IAM::Role

--- a/cloudformation.yml
+++ b/cloudformation.yml
@@ -22,6 +22,12 @@ Parameters:
     Type: String
     Default: RS256
 
+  DomainName:
+    Type: String
+
+  CertificateArn:
+    Type: String
+
 Outputs:
 
   ApiUrl:
@@ -37,6 +43,8 @@ Resources:
         RtcGammaJobDefinition: !GetAtt Cluster.Outputs.RtcGammaJobDefinition
         AuthPublicKey: !Ref AuthPublicKey
         AuthAlgorithm: !Ref AuthAlgorithm
+        DomainName: !Ref DomainName
+        CertificateArn: !Ref CertificateArn
       TemplateURL: api/cloudformation.yml
 
   Cluster:


### PR DESCRIPTION
This will make the two apis available at
https://hyp3-test-api.asf.alaska.edu/ui
https://hyp3-api.asf.alaska.edu/ui

This makes it impossible to deploy the api stack without providing a valid certificate arn.  That could be too restrictive.  We could move the DomainName and BasePathMapping resources out of the api stack and into the top level hyp3/cloudformation.yml, but I don't know that that buys us much.

We could also reject this PR, and make configuring the custom domain name a completely manual process, but I don't like that approach much, either.  I'm comfortable moving forward as-is for now.