### PR TITLE
add cors for *.asf.alaska.edu origins

### DIFF
--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -5,3 +5,4 @@ flask_api
 PyJWT
 cryptography
 serverless_wsgi
+Flask-Cors

--- a/api/src/hyp3_api/handlers.py
+++ b/api/src/hyp3_api/handlers.py
@@ -1,8 +1,7 @@
 from os import environ
 
-from hyp3_api import BATCH_CLIENT, connexion_app
 from flask_cors import CORS
-
+from hyp3_api import BATCH_CLIENT, connexion_app
 
 
 def submit_job(body):

--- a/api/src/hyp3_api/handlers.py
+++ b/api/src/hyp3_api/handlers.py
@@ -1,6 +1,8 @@
 from os import environ
 
 from hyp3_api import BATCH_CLIENT, connexion_app
+from flask_cors import CORS
+
 
 
 def submit_job(body):
@@ -18,3 +20,4 @@ def submit_job(body):
 
 
 connexion_app.add_api('openapi-spec.yml')
+CORS(connexion_app.app, origins=r'https?://([-\w]+\.)*asf\.alaska\.edu', supports_credentials=True)

--- a/api/tests/test_hyp3_api.py
+++ b/api/tests/test_hyp3_api.py
@@ -144,7 +144,7 @@ def test_cors_no_origin(client):
     assert 'Access-Control-Allow-Credentials' not in response.headers
 
 
-def test_cors_bad_origins(client, batch_stub):
+def test_cors_bad_origins(client):
     response = client.post(JOBS_URI, headers={'Origin': 'https://www.google.com'})
     assert 'Access-Control-Allow-Origin' not in response.headers
     assert 'Access-Control-Allow-Credentials' not in response.headers
@@ -154,7 +154,7 @@ def test_cors_bad_origins(client, batch_stub):
     assert 'Access-Control-Allow-Credentials' not in response.headers
 
 
-def test_cors_good_origins(client, batch_stub):
+def test_cors_good_origins(client):
     response = client.post(JOBS_URI, headers={'Origin': 'https://search.asf.alaska.edu'})
     assert response.headers['Access-Control-Allow-Origin'] == 'https://search.asf.alaska.edu'
     assert response.headers['Access-Control-Allow-Credentials'] == 'true'

--- a/api/tests/test_hyp3_api.py
+++ b/api/tests/test_hyp3_api.py
@@ -136,3 +136,33 @@ def test_jobs_bad_method(client):
 def test_no_route(client):
     response = client.get('/no/such/path')
     assert response.status_code == status.HTTP_404_NOT_FOUND
+
+
+def test_cors_no_origin(client):
+    response = client.post(JOBS_URI)
+    assert 'Access-Control-Allow-Origin' not in response.headers
+    assert 'Access-Control-Allow-Credentials' not in response.headers
+
+
+def test_cors_bad_origins(client, batch_stub):
+    response = client.post(JOBS_URI, headers={'Origin': 'https://www.google.com'})
+    assert 'Access-Control-Allow-Origin' not in response.headers
+    assert 'Access-Control-Allow-Credentials' not in response.headers
+
+    response = client.post(JOBS_URI, headers={'Origin': 'https://www.alaska.edu'})
+    assert 'Access-Control-Allow-Origin' not in response.headers
+    assert 'Access-Control-Allow-Credentials' not in response.headers
+
+
+def test_cors_good_origins(client, batch_stub):
+    response = client.post(JOBS_URI, headers={'Origin': 'https://search.asf.alaska.edu'})
+    assert response.headers['Access-Control-Allow-Origin'] == 'https://search.asf.alaska.edu'
+    assert response.headers['Access-Control-Allow-Credentials'] == 'true'
+
+    response = client.post(JOBS_URI, headers={'Origin': 'https://search-test.asf.alaska.edu'})
+    assert response.headers['Access-Control-Allow-Origin'] == 'https://search-test.asf.alaska.edu'
+    assert response.headers['Access-Control-Allow-Credentials'] == 'true'
+
+    response = client.post(JOBS_URI, headers={'Origin': 'http://local.asf.alaska.edu'})
+    assert response.headers['Access-Control-Allow-Origin'] == 'http://local.asf.alaska.edu'
+    assert response.headers['Access-Control-Allow-Credentials'] == 'true'


### PR DESCRIPTION
Here's CORS if we're comfortable hardcoding the origin regex.  We cloud lift that all the way to a cloudformation stack parameter, or maybe just make it a global constant in the python script so it pops out a little more clearly that we're setting a magic string.

`client.get('/')` might be a more generic test than `client.post('/jobs')`, we're enabling CORS for *all* responses, but `post('/jobs')` is the only one vertex will be invoking at the moment