### PR TITLE
start/end parameters for GET /jobs

### DIFF
--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -7,3 +7,4 @@ PyJWT
 cryptography
 serverless_wsgi
 Flask-Cors
+strict-rfc3339

--- a/api/src/hyp3_api/handlers.py
+++ b/api/src/hyp3_api/handlers.py
@@ -37,9 +37,9 @@ def get_jobs(user, status_code=None, start=None, end=None):
     if status_code is not None:
         filter_expression = filter_expression & Attr('status_code').eq(status_code)
     if start:
-        filter_expression = filter_expression & Attr('start_time').gte(start)
+        filter_expression = filter_expression & Attr('request_time').gte(start)
     if end:
-        filter_expression = filter_expression & Attr('start_time').lte(end)
+        filter_expression = filter_expression & Attr('request_time').lte(end)
     response = table.query(
         IndexName='user_id',
         KeyConditionExpression=Key('user_id').eq(user),

--- a/api/src/hyp3_api/handlers.py
+++ b/api/src/hyp3_api/handlers.py
@@ -31,11 +31,15 @@ def post_jobs(body, user):
     return [{'job_id': job_id} for job_id in job_ids]
 
 
-def get_jobs(user, status_code=None):
+def get_jobs(user, status_code=None, start=None, end=None):
     table = DYNAMODB_RESOURCE.Table(environ['TABLE_NAME'])
     filter_expression = Attr('job_id').exists()
     if status_code is not None:
         filter_expression = filter_expression & Attr('status_code').eq(status_code)
+    if start:
+        filter_expression = filter_expression & Attr('start_time').gte(start)
+    if end:
+        filter_expression = filter_expression & Attr('start_time').lte(end)
     response = table.query(
         IndexName='user_id',
         KeyConditionExpression=Key('user_id').eq(user),
@@ -44,5 +48,5 @@ def get_jobs(user, status_code=None):
     return {'jobs': response['Items']}
 
 
-connexion_app.add_api('openapi-spec.yml', validate_responses=True)
+connexion_app.add_api('openapi-spec.yml', validate_responses=True, strict_validation=True)
 CORS(connexion_app.app, origins=r'https?://([-\w]+\.)*asf\.alaska\.edu', supports_credentials=True)

--- a/api/src/hyp3_api/openapi-spec.yml
+++ b/api/src/hyp3_api/openapi-spec.yml
@@ -34,6 +34,14 @@ paths:
           in: query
           schema:
             $ref: "#/components/schemas/status_code"
+        - name: start
+          in: query
+          schema:
+            $ref: "#/components/schemas/datetime"
+        - name: end
+          in: query
+          schema:
+            $ref: "#/components/schemas/datetime"
       responses:
         "200":
           description: 200 response
@@ -120,7 +128,7 @@ components:
         job_parameters:
           $ref: "#/components/schemas/job_parameters"
         start_time:
-          $ref: "#/components/schemas/start_time"
+          $ref: "#/components/schemas/datetime"
         status_code:
           $ref: "#/components/schemas/status_code"
         description:
@@ -160,7 +168,7 @@ components:
       example: S1B_IW_SLC__1SDV_20200604T082207_20200604T082234_021881_029874_5E38
       description: The name of the Sentinel-1 granule to process.  Only SLC products with beam mode IW are supported.
 
-    start_time:
+    datetime:
       type: string
       format: date-time
       example: 2020-06-04T18:00:03.548Z

--- a/api/src/hyp3_api/openapi-spec.yml
+++ b/api/src/hyp3_api/openapi-spec.yml
@@ -115,7 +115,7 @@ components:
         - user_id
         - job_type
         - job_parameters
-        - start_time
+        - request_time
         - status_code
       additionalProperties: false
       properties:
@@ -127,7 +127,7 @@ components:
           $ref: "#/components/schemas/job_type"
         job_parameters:
           $ref: "#/components/schemas/job_parameters"
-        start_time:
+        request_time:
           $ref: "#/components/schemas/datetime"
         status_code:
           $ref: "#/components/schemas/status_code"

--- a/api/tests/test_hyp3_api.py
+++ b/api/tests/test_hyp3_api.py
@@ -48,7 +48,7 @@ def make_db_record(job_id,
                    granule='S1A_IW_SLC__1SDV_20200610T173646_20200610T173704_032958_03D14C_5F2B',
                    job_type='RTC_GAMMA',
                    user_id=DEFAULT_USERNAME,
-                   start_time='2020-06-10T22:13:47.622Z',
+                   request_time='2020-06-10T22:13:47.622Z',
                    status_code='RUNNING',
                    files=None):
     record = {
@@ -58,7 +58,7 @@ def make_db_record(job_id,
         'job_parameters': {
             'granule': granule,
         },
-        'start_time': start_time,
+        'request_time': request_time,
         'status_code': status_code,
     }
     if files is not None:
@@ -257,9 +257,9 @@ def test_list_jobs_bad_status(client):
 @mock_dynamodb2
 def test_list_jobs_by_date(client):
     items = [
-        make_db_record('0ddaeb98-7636-494d-9496-03ea4a7df266', start_time='2018-01-01T00:00:00.000Z'),
-        make_db_record('27836b79-e5b2-4d8f-932f-659724ea02c3', start_time='2019-01-01T00:00:00.000Z'),
-        make_db_record('c4617ae4-c7e1-4ada-bb6f-9e06a4a2d5e7', start_time='2020-01-01T00:00:00.000Z'),
+        make_db_record('0ddaeb98-7636-494d-9496-03ea4a7df266', request_time='2018-01-01T00:00:00.000Z'),
+        make_db_record('27836b79-e5b2-4d8f-932f-659724ea02c3', request_time='2019-01-01T00:00:00.000Z'),
+        make_db_record('c4617ae4-c7e1-4ada-bb6f-9e06a4a2d5e7', request_time='2020-01-01T00:00:00.000Z'),
     ]
     setup_database(items)
 

--- a/api/tests/test_hyp3_api.py
+++ b/api/tests/test_hyp3_api.py
@@ -268,7 +268,8 @@ def test_list_jobs_by_date(client):
     assert response.status_code == status.HTTP_200_OK
     assert response.json == {'jobs': [items[0]]}
 
-    response = client.get(JOBS_URI, query_string={'start': '2019-01-01T00:00:00.000Z', 'end': '2019-01-01T00:00:00.000Z'})
+    parameters = {'start': '2019-01-01T00:00:00.000Z', 'end': '2019-01-01T00:00:00.000Z'}
+    response = client.get(JOBS_URI, query_string=parameters)
     assert response.status_code == status.HTTP_200_OK
     assert response.json == {'jobs': [items[1]]}
 

--- a/step-function/cloudformation.yml
+++ b/step-function/cloudformation.yml
@@ -46,7 +46,7 @@ Resources:
                 "user_id.$": "$.user_id",
                 "status_code": "RUNNING",
                 "job_parameters.$": "$.job_parameters",
-                "start_time.$": "$$.Execution.StartTime",
+                "request_time.$": "$$.Execution.StartTime",
                 "description.$": "$.description"
               },
               "ResultPath": "$.results.job_running",


### PR DESCRIPTION
The dynamodb filter is just doing string comparison.  I think that's compatible with date-time, unless `format: date-time` allows for time zones other than `Z`.

Need `strict-rfc3339` in requirements.txt for `format: date-time`, see https://github.com/zalando/connexion/issues/476

Enabled `strict_validation=True` so we now throw HTTP 400 if the user provides query parameters not listed in the spec.

I'm starting to like `request_time` better than `start_time` for the field name in the DB table.  I'd also consider `before` and `after` for the query parameters rather than `start` and `end`; I think it makes the comparisons more self-evident.