### PR TITLE
add end query parameter to GET /jobs

### DIFF
--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -8,5 +8,4 @@ cryptography
 serverless_wsgi
 Flask-Cors
 strict-rfc3339
-pytz
 PyYAML

--- a/api/src/hyp3_api/handlers.py
+++ b/api/src/hyp3_api/handlers.py
@@ -69,7 +69,7 @@ def get_jobs(user, start=None, end=None, status_code=None):
 
 def format_time(time: datetime):
     if time.tzinfo is None:
-        raise ValueError(f'no timezone provided for {time}')
+        raise ValueError(f'missing tzinfo for datetime {time}')
     utc_time = time.astimezone(timezone.utc)
     return utc_time.isoformat(timespec='seconds')
 

--- a/api/src/hyp3_api/handlers.py
+++ b/api/src/hyp3_api/handlers.py
@@ -83,7 +83,7 @@ def check_quota_for_user(user, number_of_jobs):
 
 
 def get_job_count_for_month(user):
-    now = datetime.utcnow()
+    now = datetime.now(timezone.utc)
     start_of_month = datetime(year=now.year, month=now.month, day=1, tzinfo=timezone.utc)
     response = get_jobs(user, format_time(start_of_month))
     return len(response['jobs'])

--- a/api/src/hyp3_api/handlers.py
+++ b/api/src/hyp3_api/handlers.py
@@ -84,7 +84,7 @@ def check_quota_for_user(user, number_of_jobs):
 
 def get_job_count_for_month(user):
     now = datetime.now(timezone.utc)
-    start_of_month = datetime(year=now.year, month=now.month, day=1, tzinfo=timezone.utc)
+    start_of_month = now.replace(day=1, hour=0, minute=0, second=0, microsecond=0)
     response = get_jobs(user, format_time(start_of_month))
     return len(response['jobs'])
 

--- a/api/src/hyp3_api/handlers.py
+++ b/api/src/hyp3_api/handlers.py
@@ -73,15 +73,11 @@ def get_jobs(user, start=None, end=None, status_code=None):
 
 
 def format_time(time: datetime):
-    utc_time = convert_to_utc(time)
-    return utc_time.isoformat(timespec='seconds') + 'Z'
-
-
-def convert_to_utc(time: datetime):
     if time.tzinfo is not None:
-        return time.astimezone(pytz.UTC)
+        utc_time = time.astimezone(pytz.UTC)
+        return utc_time.isoformat(timespec='seconds')
     else:
-        return time
+        return time.isoformat(timespec='seconds') + '+00:00'
 
 
 def check_quota_for_user(user, number_of_jobs):

--- a/api/src/hyp3_api/handlers.py
+++ b/api/src/hyp3_api/handlers.py
@@ -91,8 +91,8 @@ def get_job_count_for_month(user):
 
 def get_request_time_expression(start, end):
     key = Key('request_time')
-    formatted_start = format_time(parse(start)) if start else None
-    formatted_end = format_time(parse(end)) if end else None
+    formatted_start = (format_time(parse(start)) if start else None)
+    formatted_end = (format_time(parse(end)) if end else None)
 
     if formatted_start and formatted_end:
         return key.between(formatted_start, formatted_end)

--- a/api/src/hyp3_api/handlers.py
+++ b/api/src/hyp3_api/handlers.py
@@ -52,10 +52,14 @@ def get_jobs(user, start=None, end=None, status_code=None):
     table = DYNAMODB_RESOURCE.Table(environ['TABLE_NAME'])
 
     key_expression = Key('user_id').eq(user)
-    if start is not None:
+    if start is not None and end is not None:
+        formatted_start = format_time(parse(start))
+        formatted_end = format_time(parse(end))
+        key_expression &= Key('request_time').between(formatted_start, formatted_end)
+    elif start is not None:
         formatted_start = format_time(parse(start))
         key_expression &= Key('request_time').gte(formatted_start)
-    if end is not None:
+    elif end is not None:
         formatted_end = format_time(parse(end))
         key_expression &= Key('request_time').lte(formatted_end)
 

--- a/api/src/hyp3_api/handlers.py
+++ b/api/src/hyp3_api/handlers.py
@@ -48,13 +48,16 @@ def post_jobs(body, user):
     return body
 
 
-def get_jobs(user, start=None, status_code=None):
+def get_jobs(user, start=None, end=None, status_code=None):
     table = DYNAMODB_RESOURCE.Table(environ['TABLE_NAME'])
 
     key_expression = Key('user_id').eq(user)
     if start is not None:
-        datetime_start = parse(start)
-        key_expression &= Key('request_time').gte(format_time(datetime_start))
+        formatted_start = format_time(parse(start))
+        key_expression &= Key('request_time').gte(formatted_start)
+    if end is not None:
+        formatted_end = format_time(parse(end))
+        key_expression &= Key('request_time').lte(formatted_end)
 
     filter_expression = Attr('job_id').exists()
     if status_code is not None:

--- a/api/src/hyp3_api/openapi-spec.yml
+++ b/api/src/hyp3_api/openapi-spec.yml
@@ -38,6 +38,10 @@ paths:
           in: query
           schema:
             $ref: "#/components/schemas/datetime"
+        - name: end
+          in: query
+          schema:
+            $ref: "#/components/schemas/datetime"
       responses:
         "200":
           description: 200 response

--- a/api/src/hyp3_api/openapi-spec.yml
+++ b/api/src/hyp3_api/openapi-spec.yml
@@ -162,7 +162,7 @@ components:
     datetime:
       type: string
       format: date-time
-      example: 2020-06-04T18:00:03Z
+      example: 2020-06-04T18:00:03+00:00
 
     status_code:
       type: string

--- a/api/tests/conftest.py
+++ b/api/tests/conftest.py
@@ -63,9 +63,9 @@ def make_db_record(job_id,
                    granule='S1A_IW_SLC__1SDV_20200610T173646_20200610T173704_032958_03D14C_5F2B',
                    job_type='RTC_GAMMA',
                    user_id=DEFAULT_USERNAME,
-                   request_time='2019-12-31T15:00:00Z',
+                   request_time='2019-12-31T15:00:00+00:00',
                    status_code='RUNNING',
-                   expiration_time='2019-12-31T15:00:00Z',
+                   expiration_time='2019-12-31T15:00:00+00:00',
                    files=None):
     record = {
         'job_id': job_id,

--- a/api/tests/test_list_jobs.py
+++ b/api/tests/test_list_jobs.py
@@ -91,7 +91,7 @@ def test_list_jobs_by_start(client, table):
     assert response.json == {'jobs': []}
 
 
-def test_list_jobs_by_start_formats(client, table):
+def test_list_jobs_date_formats(client, table):
     items = [
         make_db_record('874f7533-807d-4b20-afe1-27b5b6fc9d6c', request_time='2019-12-31T10:00:00+00:00'),
         make_db_record('0ddaeb98-7636-494d-9496-03ea4a7df266', request_time='2019-12-31T10:00:10+00:00'),

--- a/api/tests/test_list_jobs.py
+++ b/api/tests/test_list_jobs.py
@@ -69,55 +69,11 @@ def test_list_jobs_bad_status(client):
     assert response.status_code == status.HTTP_400_BAD_REQUEST
 
 
-def test_list_jobs_by_start(client, table):
+def test_list_jobs_date_start_and_end(client, table):
     items = [
-        make_db_record('0ddaeb98-7636-494d-9496-03ea4a7df266', request_time='2019-12-31T15:00:00+00:00'),
-        make_db_record('27836b79-e5b2-4d8f-932f-659724ea02c3', request_time='2019-12-31T15:00:10+00:00'),
-    ]
-    for item in items:
-        table.put_item(Item=item)
-
-    login(client)
-    response = client.get(JOBS_URI, query_string={'start': '2019-12-31T15:00:00+00:00'})
-    assert response.status_code == status.HTTP_200_OK
-    assert response.json == {'jobs': items}
-
-    response = client.get(JOBS_URI, query_string={'start': '2019-12-31T15:00:10+00:00'})
-    assert response.status_code == status.HTTP_200_OK
-    assert response.json == {'jobs': [items[1]]}
-
-    response = client.get(JOBS_URI, query_string={'start': '2019-12-31T15:00:11+00:00'})
-    assert response.status_code == status.HTTP_200_OK
-    assert response.json == {'jobs': []}
-
-
-def test_list_jobs_by_end(client, table):
-    items = [
-        make_db_record('0ddaeb98-7636-494d-9496-03ea4a7df266', request_time='2019-12-31T15:00:00+00:00'),
-        make_db_record('27836b79-e5b2-4d8f-932f-659724ea02c3', request_time='2019-12-31T15:00:10+00:00'),
-    ]
-    for item in items:
-        table.put_item(Item=item)
-
-    login(client)
-    response = client.get(JOBS_URI, query_string={'end': '2019-12-30T23:59:59+00:00'})
-    assert response.status_code == status.HTTP_200_OK
-    assert response.json == {'jobs': []}
-
-    response = client.get(JOBS_URI, query_string={'end': '2019-12-31T15:00:00+00:00'})
-    assert response.status_code == status.HTTP_200_OK
-    assert response.json == {'jobs': [items[0]]}
-
-    response = client.get(JOBS_URI, query_string={'end': '2019-12-31T15:00:10+00:00'})
-    assert response.status_code == status.HTTP_200_OK
-    assert response.json == {'jobs': items}
-
-
-def test_list_jobs_date_formats(client, table):
-    items = [
-        make_db_record('874f7533-807d-4b20-afe1-27b5b6fc9d6c', request_time='2019-12-31T10:00:00+00:00'),
+        make_db_record('874f7533-807d-4b20-afe1-27b5b6fc9d6c', request_time='2019-12-31T10:00:09+00:00'),
         make_db_record('0ddaeb98-7636-494d-9496-03ea4a7df266', request_time='2019-12-31T10:00:10+00:00'),
-        make_db_record('27836b79-e5b2-4d8f-932f-659724ea02c3', request_time='2019-12-31T10:00:20+00:00'),
+        make_db_record('27836b79-e5b2-4d8f-932f-659724ea02c3', request_time='2019-12-31T10:00:11+00:00'),
     ]
     for item in items:
         table.put_item(Item=item)

--- a/api/tests/test_list_jobs.py
+++ b/api/tests/test_list_jobs.py
@@ -82,13 +82,35 @@ def test_list_jobs_by_start(client, table):
     assert response.status_code == status.HTTP_200_OK
     assert response.json == {'jobs': items}
 
-    response = client.get(JOBS_URI, query_string={'start': '2019-12-31T15:00:10Z'})
+    response = client.get(JOBS_URI, query_string={'start': '2019-12-31T15:00:10+00:00'})
     assert response.status_code == status.HTTP_200_OK
     assert response.json == {'jobs': [items[1]]}
 
-    response = client.get(JOBS_URI, query_string={'start': '2019-12-31T15:00:11Z'})
+    response = client.get(JOBS_URI, query_string={'start': '2019-12-31T15:00:11+00:00'})
     assert response.status_code == status.HTTP_200_OK
     assert response.json == {'jobs': []}
+
+
+def test_list_jobs_by_end(client, table):
+    items = [
+        make_db_record('0ddaeb98-7636-494d-9496-03ea4a7df266', request_time='2019-12-31T15:00:00+00:00'),
+        make_db_record('27836b79-e5b2-4d8f-932f-659724ea02c3', request_time='2019-12-31T15:00:10+00:00'),
+    ]
+    for item in items:
+        table.put_item(Item=item)
+
+    login(client)
+    response = client.get(JOBS_URI, query_string={'end': '2019-12-30T23:59:59+00:00'})
+    assert response.status_code == status.HTTP_200_OK
+    assert response.json == {'jobs': []}
+
+    response = client.get(JOBS_URI, query_string={'end': '2019-12-31T15:00:00+00:00'})
+    assert response.status_code == status.HTTP_200_OK
+    assert response.json == {'jobs': [items[0]]}
+
+    response = client.get(JOBS_URI, query_string={'end': '2019-12-31T15:00:10+00:00'})
+    assert response.status_code == status.HTTP_200_OK
+    assert response.json == {'jobs': items}
 
 
 def test_list_jobs_date_formats(client, table):

--- a/api/tests/test_list_jobs.py
+++ b/api/tests/test_list_jobs.py
@@ -25,16 +25,12 @@ def test_list_jobs(client, table):
     login(client, 'user_with_jobs')
     response = client.get(JOBS_URI)
     assert response.status_code == status.HTTP_200_OK
-    assert response.json == {
-        'jobs': items,
-    }
+    assert response.json == {'jobs': items}
 
     login(client, 'user_without_jobs')
     response = client.get(JOBS_URI)
     assert response.status_code == status.HTTP_200_OK
-    assert response.json == {
-        'jobs': [],
-    }
+    assert response.json == {'jobs': []}
 
 
 def test_list_jobs_not_authorized(client, table):
@@ -130,6 +126,7 @@ def test_list_jobs_by_start_formats(client, table):
 
 
 def test_bad_date_formats(client):
+    datetime_parameters = ['start', 'end']
     bad_dates = [
       '',
       'foo',
@@ -143,9 +140,8 @@ def test_bad_date_formats(client):
       '2020-01-01T00:00:00+0100',
       '2020-01-01T00:00:00-24:00',
     ]
-    datetime_parameters = ['start', 'end']
     login(client)
-    for bad_date in bad_dates:
-        for datetime_parameter in datetime_parameters:
+    for datetime_parameter in datetime_parameters:
+        for bad_date in bad_dates:
             response = client.get(JOBS_URI, query_string={datetime_parameter: bad_date})
             assert response.status_code == status.HTTP_400_BAD_REQUEST

--- a/api/tests/test_list_jobs.py
+++ b/api/tests/test_list_jobs.py
@@ -51,8 +51,7 @@ def test_list_jobs_by_status(client, table):
     login(client)
     response = client.get(JOBS_URI, query_string={'status_code': 'RUNNING'})
     assert response.status_code == status.HTTP_200_OK
-    assert response.json['jobs'][0] == items[0]
-    assert len(response.json['jobs']) == 1
+    assert response.json == {'jobs': [items[0]]}
 
     response = client.get(JOBS_URI, query_string={'status_code': 'FAILED'})
     assert response.status_code == status.HTTP_200_OK

--- a/api/tests/test_list_jobs.py
+++ b/api/tests/test_list_jobs.py
@@ -84,9 +84,7 @@ def test_list_jobs_by_start(client, table):
     login(client)
     response = client.get(JOBS_URI, query_string={'start': '2019-12-31T15:00:00+00:00'})
     assert response.status_code == status.HTTP_200_OK
-    assert items[0] in response.json['jobs']
-    assert items[1] in response.json['jobs']
-    assert len(response.json['jobs']) == 2
+    assert response.json == {'jobs': items}
 
     response = client.get(JOBS_URI, query_string={'start': '2019-12-31T15:00:10Z'})
     assert response.status_code == status.HTTP_200_OK
@@ -120,15 +118,11 @@ def test_list_jobs_by_start_formats(client, table):
     for date in dates:
         response = client.get(JOBS_URI, query_string={'start': date})
         assert response.status_code == status.HTTP_200_OK
-        assert items[1] in response.json['jobs']
-        assert items[2] in response.json['jobs']
-        assert len(response.json['jobs']) == 2
+        assert response.json == {'jobs': items[1:]}
 
         response = client.get(JOBS_URI, query_string={'end': date})
         assert response.status_code == status.HTTP_200_OK
-        assert items[0] in response.json['jobs']
-        assert items[1] in response.json['jobs']
-        assert len(response.json['jobs']) == 2
+        assert response.json == {'jobs': items[:2]}
 
         response = client.get(JOBS_URI, query_string={'start': date, 'end': date})
         assert response.status_code == status.HTTP_200_OK
@@ -149,9 +143,9 @@ def test_bad_date_formats(client):
       '2020-01-01T00:00:00+0100',
       '2020-01-01T00:00:00-24:00',
     ]
+    datetime_parameters = ['start', 'end']
     login(client)
     for bad_date in bad_dates:
-        response = client.get(JOBS_URI, query_string={'start': bad_date})
-        assert response.status_code == status.HTTP_400_BAD_REQUEST
-        response = client.get(JOBS_URI, query_string={'end': bad_date})
-        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        for datetime_parameter in datetime_parameters:
+            response = client.get(JOBS_URI, query_string={datetime_parameter: bad_date})
+            assert response.status_code == status.HTTP_400_BAD_REQUEST

--- a/api/tests/test_list_jobs.py
+++ b/api/tests/test_list_jobs.py
@@ -55,8 +55,8 @@ def test_list_jobs_by_status(client, table):
     login(client)
     response = client.get(JOBS_URI, query_string={'status_code': 'RUNNING'})
     assert response.status_code == status.HTTP_200_OK
-    assert len(response.json['jobs']) == 1
     assert response.json['jobs'][0] == items[0]
+    assert len(response.json['jobs']) == 1
 
     response = client.get(JOBS_URI, query_string={'status_code': 'FAILED'})
     assert response.status_code == status.HTTP_200_OK
@@ -84,9 +84,9 @@ def test_list_jobs_by_start(client, table):
     login(client)
     response = client.get(JOBS_URI, query_string={'start': '2019-12-31T15:00:00Z'})
     assert response.status_code == status.HTTP_200_OK
-    assert len(response.json['jobs']) == 2
     assert items[0] in response.json['jobs']
     assert items[1] in response.json['jobs']
+    assert len(response.json['jobs']) == 2
 
     response = client.get(JOBS_URI, query_string={'start': '2019-12-31T15:00:10Z'})
     assert response.status_code == status.HTTP_200_OK
@@ -120,9 +120,16 @@ def test_list_jobs_by_start_formats(client, table):
     for date in dates:
         response = client.get(JOBS_URI, query_string={'start': date})
         assert response.status_code == status.HTTP_200_OK
-        assert len(response.json['jobs']) == 2
         assert items[1] in response.json['jobs']
         assert items[2] in response.json['jobs']
+        assert len(response.json['jobs']) == 2
+
+        response = client.get(JOBS_URI, query_string={'end': date})
+        print(response.json)
+        assert response.status_code == status.HTTP_200_OK
+        assert items[0] in response.json['jobs']
+        assert items[1] in response.json['jobs']
+        assert len(response.json['jobs']) == 2
 
 
 def test_bad_date_formats(client):
@@ -142,4 +149,6 @@ def test_bad_date_formats(client):
     login(client)
     for bad_date in bad_dates:
         response = client.get(JOBS_URI, query_string={'start': bad_date})
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        response = client.get(JOBS_URI, query_string={'end': bad_date})
         assert response.status_code == status.HTTP_400_BAD_REQUEST

--- a/api/tests/test_list_jobs.py
+++ b/api/tests/test_list_jobs.py
@@ -75,14 +75,14 @@ def test_list_jobs_bad_status(client):
 
 def test_list_jobs_by_start(client, table):
     items = [
-        make_db_record('0ddaeb98-7636-494d-9496-03ea4a7df266', request_time='2019-12-31T15:00:00Z'),
-        make_db_record('27836b79-e5b2-4d8f-932f-659724ea02c3', request_time='2019-12-31T15:00:10Z'),
+        make_db_record('0ddaeb98-7636-494d-9496-03ea4a7df266', request_time='2019-12-31T15:00:00+00:00'),
+        make_db_record('27836b79-e5b2-4d8f-932f-659724ea02c3', request_time='2019-12-31T15:00:10+00:00'),
     ]
     for item in items:
         table.put_item(Item=item)
 
     login(client)
-    response = client.get(JOBS_URI, query_string={'start': '2019-12-31T15:00:00Z'})
+    response = client.get(JOBS_URI, query_string={'start': '2019-12-31T15:00:00+00:00'})
     assert response.status_code == status.HTTP_200_OK
     assert items[0] in response.json['jobs']
     assert items[1] in response.json['jobs']
@@ -99,9 +99,9 @@ def test_list_jobs_by_start(client, table):
 
 def test_list_jobs_by_start_formats(client, table):
     items = [
-        make_db_record('874f7533-807d-4b20-afe1-27b5b6fc9d6c', request_time='2019-12-31T10:00:00Z'),
-        make_db_record('0ddaeb98-7636-494d-9496-03ea4a7df266', request_time='2019-12-31T10:00:10Z'),
-        make_db_record('27836b79-e5b2-4d8f-932f-659724ea02c3', request_time='2019-12-31T10:00:20Z'),
+        make_db_record('874f7533-807d-4b20-afe1-27b5b6fc9d6c', request_time='2019-12-31T10:00:00+00:00'),
+        make_db_record('0ddaeb98-7636-494d-9496-03ea4a7df266', request_time='2019-12-31T10:00:10+00:00'),
+        make_db_record('27836b79-e5b2-4d8f-932f-659724ea02c3', request_time='2019-12-31T10:00:20+00:00'),
     ]
     for item in items:
         table.put_item(Item=item)

--- a/api/tests/test_list_jobs.py
+++ b/api/tests/test_list_jobs.py
@@ -125,11 +125,14 @@ def test_list_jobs_by_start_formats(client, table):
         assert len(response.json['jobs']) == 2
 
         response = client.get(JOBS_URI, query_string={'end': date})
-        print(response.json)
         assert response.status_code == status.HTTP_200_OK
         assert items[0] in response.json['jobs']
         assert items[1] in response.json['jobs']
         assert len(response.json['jobs']) == 2
+
+        response = client.get(JOBS_URI, query_string={'start': date, 'end': date})
+        assert response.status_code == status.HTTP_200_OK
+        assert response.json == {'jobs': [items[1]]}
 
 
 def test_bad_date_formats(client):

--- a/api/tests/test_submit_job.py
+++ b/api/tests/test_submit_job.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from os import environ
 
 from conftest import DEFAULT_USERNAME, login, make_db_record, make_job, submit_batch
@@ -13,7 +13,7 @@ def test_submit_one_job(client, table):
     jobs = response.json['jobs']
     assert len(jobs) == 1
     assert jobs[0]['status_code'] == 'PENDING'
-    assert jobs[0]['request_time'] <= format_time(datetime.utcnow())
+    assert jobs[0]['request_time'] <= format_time(datetime.now(timezone.utc))
     assert jobs[0]['user_id'] == DEFAULT_USERNAME
 
 
@@ -36,7 +36,7 @@ def test_submit_many_jobs(client, table):
 
 def test_submit_exceeds_quota(client, table):
     login(client)
-    time_for_previous_month = format_time(datetime.utcnow() - timedelta(days=32))
+    time_for_previous_month = format_time(datetime.now(timezone.utc) - timedelta(days=32))
     job_from_previous_month = make_db_record('0ddaeb98-7636-494d-9496-03ea4a7df266',
                                              request_time=time_for_previous_month)
     table.put_item(Item=job_from_previous_month)

--- a/step-function/get-files/src/main.py
+++ b/step-function/get-files/src/main.py
@@ -17,7 +17,7 @@ def get_expiration_time(key):
     s3_object = S3_CLIENT.get_object(Bucket=environ['BUCKET'], Key=key)
     expiration_string = s3_object['Expiration'].split('"')[1]
     expiration_datetime = datetime.strptime(expiration_string, '%a, %d %b %Y %H:%M:%S %Z')
-    return expiration_datetime.isoformat(timespec='seconds') + 'Z'
+    return expiration_datetime.isoformat(timespec='seconds') + '+00:00'
 
 
 def lambda_handler(event, context):


### PR DESCRIPTION
Also:
- format datetimes in database with `+00:00` time zone instead of `Z`
- make all datetime objects timezone-aware
- use `datetime.timezone.utc` instead of `pytz.UTC`